### PR TITLE
Emoji Support & other fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,19 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
+    "emoji-datasource": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/emoji-datasource/-/emoji-datasource-4.1.0.tgz",
+      "integrity": "sha1-tEVX94ot+sLzUDkzkbFwpWfsKK0="
+    },
+    "emoji-js": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-js/-/emoji-js-3.5.0.tgz",
+      "integrity": "sha512-5uaULzdR3g6ALBC8xUzyoxAx6izT1M4+DEsxHLRS2/gaOKC/p62831itMoMsYfUj1fKX3YG01u5YVz2v7qpsWg==",
+      "requires": {
+        "emoji-datasource": "4.1.0"
+      }
+    },
     "endian-toggle": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/endian-toggle/-/endian-toggle-0.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "colors": "^1.4.0",
     "discord.js": "^12.0.0",
     "dotenv": "^8.2.0",
+    "emoji-js": "^3.5.0",
     "mineflayer": "^2.28.1"
   }
 }


### PR DESCRIPTION
What this does:

- Both emojis and custom emojis are handled properly when sent from Discord to Minecraft.
- Can no longer send empty messages.
- Can no longer send "ez" and cause the bot to get filtered.
- Fixes the way mentions are handled when sent to Minecraft.
- Removed some repeating code.